### PR TITLE
Massively reduce `rearrange`/`repeat`/`reduce` overhead

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,80 +17,88 @@
 
 </div>
 
-> Einops.jl brings the readable and concise tensor operations of [einops](https://einops.rocks) to Julia, unifying `reshape`, `permutedims`, `reduce` and `repeat` functions, with support for automatic differentiation.
+> Einops.jl brings the readable and concise tensor operations of [einops](https://einops.rocks) to Julia, reliably expanding to existing primitives like `reshape`, `permutedims`, and `repeat`, with no performance overhead.
 
-## Operations
+## Einops vs Julia primitives
 
-The Python implementation uses strings to specify the exact operation, which is tricky to compile in Julia, so a string macro is exported for parity, e.g. `einops"a b -> (b a)"` expands to the form `(:a, :b) --> ((:b, :a),)`, where `-->` is a custom operator that puts the left and right operands as type parameters of a special pattern type. This allows for compile-time awareness of dimensionalities, ensuring type stability.
+Einops patterns can be constructed with the `einops` string macro, e.g. `einops"a b -> (b a)"` expands to the form `(:a, :b) --> ((:b, :a),)`, where `-->` is a custom operator that puts the left and right operands as type parameters of a special pattern type.
 
-### `rearrange`
+The snippets below show identical transformations expressed first with Einops (one readable line) and then with "hand-rolled" Julia primitives. Notice how Einops collapses multiple e.g. `reshape` / `permutedims` / `dropdims` / `repeat` calls into a single, declarative statement. Note that Einops simply expands to these primitives under the hood, and avoids no-ops, so there is little to no performance overhead.
 
-The `rearrange` combines reshaping and permutation operations into a single, expressive command.
+<table style="table-layout: fixed; width: 100%;">
 
-```julia
-julia> images = randn(3, 40, 30, 32); # channel, width, height, batch
 
-# reorder axes to "w h c b" format:
-julia> rearrange(images, (:c, :w, :h, :b) --> (:w, :h, :c, :b)) |> size
-(40, 30, 3, 32)
+  <tr>
+    <th>Einops</th>
+    <th>Julia Base primitives</th>
+  </tr>
 
-# flatten each image into a vector
-julia> rearrange(images, (:c, :w, :h, :b) --> ((:c, :w, :h), :b)) |> size
-(32, 3600)
 
-# split each image into 4 smaller (top-left, top-right, bottom-left, bottom-right), 128 = 32 * 2 * 2
-julia> rearrange(images, (:c, (:w, :w2), (:h, :h2), :b) --> (:c, :w, :h, (:w2, :h2, :b)), h2=2, w2=2) |> size
-(3, 20, 15, 128)
-```
+  <tr>
+  <td>
 
-### `reduce`
+  ```julia
+  rearrange(x, einops"a b c -> (a b) c")
+  ```
+  </td>
+  <td>
 
-The method for `Base.reduce` dispatches on `ArrowPattern`, applying reduction operations (like `sum`, `mean`, `maximum`) along specified axes. This is different from typical `Base.reduce` functionality, which reduces using binary operations.
+  ```julia
+  reshape(x, :, size(x, 3))
+  ```
+  </td>
+  </tr>
 
-```julia
-julia> x = randn(64, 32, 100);
 
-# perform max-reduction on the first axis
-# Axis t does not appear on the right - thus we reduce over t
-julia> reduce(maximum, x, (:c, :b, :t) --> (:c, :b)) |> size
-(64, 32)
+  <tr>
+  <td>
 
-julia> reduce(mean, x, (:c, :b, (:t, :t5)) --> (:b, :c, :t), t5=5) |> size
-(32, 64, 20)
-```
+  ```julia
+  rearrange(x, einops"a b c -> (b a) c")
+  ```
+  </td>
+  <td>
 
-### `repeat`
+  ```julia
+  reshape(permutedims(x, (2, 1, 3)), :, size(a, 3))
+  ```
+  </td>
+  </tr>
 
-The method for `Base.repeat` also dispatches on `ArrowPattern`, and repeats elements along existing or new axes.
 
-```julia
-julia> image = randn(40, 30); # a grayscale image (of shape height x width)
+  <tr>
+  <td>
 
-# change it to RGB format by repeating in each channel
-julia> repeat(image, (:w, :h) --> (:c, :w, :h), c=3) |> size
-(3, 40, 30)
+  ```julia
+  rearrange(q, einops"(d h) l b -> d l (h b)"; d=head_dim)
+  ```
+  </td>
+  <td>
 
-# repeat image 2 times along height (vertical axis)
-julia> repeat(image, (:w, :h) --> ((:repeat, :h), :w), repeat=2) |> size
-(60, 40)
+  ```julia
+  reshape(permutedims(reshape(q, head_dim, size(q, 1) ÷ head_dim, size(q)[2:3]), (2, 1, 3, 4)), head_dim, size(q, 2), :)
+  ```
+  </td>
+  </tr>
 
-# repeat image 2 time along height and 3 times along width
-julia> repeat(image, (:w, :h) --> ((:w, :w3), (:h, :h2)), w3=3, h2=2) |> size
-(120, 60)
-```
 
-## Roadmap
+  <tr>
+  <td>
 
-*   [x] Implement `rearrange`.
-*   [x] Support Python implementation's string syntax for patterns with string macro.
-*   [x] Implement `pack` and `unpack`.
-*   [x] Implement `parse_shape`.
-*   [x] Implement `repeat`.
-*   [x] Implement `reduce`.
-*   [x] Support automatic differentiation (tested with [Zygote.jl](https://github.com/FluxML/Zygote.jl)).
-*   [x] Implement `einsum` (or wrap existing implementation) (see https://github.com/MurrellGroup/Einops.jl/issues/3).
-*   [x] Support ellipsis notation (using `..` from [EllipsisNotation.jl](https://github.com/SciML/EllipsisNotation.jl)) (see https://github.com/MurrellGroup/Einops.jl/issues/9).
-*   [ ] Explore integration with `PermutedDimsArray` or [TransmuteDims.jl](https://github.com/mcabbott/TransmuteDims.jl) for lazy and statically inferrable permutations (see https://github.com/MurrellGroup/Einops.jl/issues/4).
+  ```julia
+  repeat(k, einops"(d h) l b -> d l (r h b)"; d=head_dim, r=repeats)
+  ```
+  </td>
+  <td>
+
+  ```julia
+  reshape(repeat(permutedims(reshape(k, head_dim, size(k, 1) ÷ head_dim, size(k)[2:3]), (2, 1, 3, 4)), inner=(1, 1, repeats)), head_dim, size(k, 2), :)
+  ```
+  </td>
+  </tr>
+
+
+</table>
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -17,88 +17,49 @@
 
 </div>
 
-> Einops.jl brings the readable and concise tensor operations of [einops](https://einops.rocks) to Julia, reliably expanding to existing primitives like `reshape`, `permutedims`, and `repeat`, with no performance overhead.
+> Einops.jl brings the readable and concise tensor operations of [einops](https://einops.rocks) to Julia, reliably expanding to existing primitives like `reshape`, `permutedims`, and `repeat`.
 
-## Einops vs Julia primitives
+## Einops vs Base primitives
 
 Einops patterns can be constructed with the `einops` string macro, e.g. `einops"a b -> (b a)"` expands to the form `(:a, :b) --> ((:b, :a),)`, where `-->` is a custom operator that puts the left and right operands as type parameters of a special pattern type.
 
 The snippets below show identical transformations expressed first with Einops (one readable line) and then with "hand-rolled" Julia primitives. Notice how Einops collapses multiple e.g. `reshape` / `permutedims` / `dropdims` / `repeat` calls into a single, declarative statement. Note that Einops simply expands to these primitives under the hood, and avoids no-ops, so there is little to no performance overhead.
 
-<table style="table-layout: fixed; width: 100%;">
+```julia
+rearrange(x, einops"a b c -> (a b) c")
+# vs
+reshape(x, :, size(x, 3))
+```
 
+```julia
+rearrange(x, einops"a b c -> b a c")
+# vs
+permutedims(x, (2, 1, 3))
+```
 
-  <tr>
-    <th>Einops</th>
-    <th>Julia Base primitives</th>
-  </tr>
+```julia
+rearrange(x, einops"1 ... -> ...")
+# vs
+dropdims(x, dims=1)
+```
 
+```julia
+repeat(x, einops"... -> 2 ... 3")
+# vs
+repeat(reshape(x, 1, size(x)...), 2, ntuple(Returns(1), ndims(x))..., 3)
+```
 
-  <tr>
-  <td>
+```julia
+rearrange(q, einops"(d h) l b -> d l (h b)"; d=head_dim)
+# vs
+reshape(permutedims(reshape(q, head_dim, size(q, 1) ÷ head_dim, size(q)[2:3]), (2, 1, 3, 4)), head_dim, size(q, 2), :)
+```
 
-  ```julia
-  rearrange(x, einops"a b c -> (a b) c")
-  ```
-  </td>
-  <td>
-
-  ```julia
-  reshape(x, :, size(x, 3))
-  ```
-  </td>
-  </tr>
-
-
-  <tr>
-  <td>
-
-  ```julia
-  rearrange(x, einops"a b c -> (b a) c")
-  ```
-  </td>
-  <td>
-
-  ```julia
-  reshape(permutedims(x, (2, 1, 3)), :, size(a, 3))
-  ```
-  </td>
-  </tr>
-
-
-  <tr>
-  <td>
-
-  ```julia
-  rearrange(q, einops"(d h) l b -> d l (h b)"; d=head_dim)
-  ```
-  </td>
-  <td>
-
-  ```julia
-  reshape(permutedims(reshape(q, head_dim, size(q, 1) ÷ head_dim, size(q)[2:3]), (2, 1, 3, 4)), head_dim, size(q, 2), :)
-  ```
-  </td>
-  </tr>
-
-
-  <tr>
-  <td>
-
-  ```julia
-  repeat(k, einops"(d h) l b -> d l (r h b)"; d=head_dim, r=repeats)
-  ```
-  </td>
-  <td>
-
-  ```julia
-  reshape(repeat(permutedims(reshape(k, head_dim, size(k, 1) ÷ head_dim, size(k)[2:3]), (2, 1, 3, 4)), inner=(1, 1, repeats)), head_dim, size(k, 2), :)
-  ```
-  </td>
-  </tr>
-
-
-</table>
+```julia
+repeat(k, einops"(d h) l b -> d l (r h b)"; d=head_dim, r=repeats)
+# vs
+reshape(repeat(permutedims(reshape(k, head_dim, size(k, 1) ÷ head_dim, size(k)[2:3]), (2, 1, 3, 4)), inner=(1, 1, repeats)), head_dim, size(k, 2), :)
+```
 
 ## Contributing
 

--- a/src/pack_unpack.jl
+++ b/src/pack_unpack.jl
@@ -44,6 +44,8 @@ function pack(unpacked_arrays, pattern::PackPattern{N}) where N
     return concatenated_array, packed_shapes
 end
 
+pack(unpacked_arrays, ::Val{T}) where T = pack(unpacked_arrays, T)
+
 splice(a::Dims, i::Int, r::Dims) = (a[1:i-1]..., r..., a[i+1:end]...)
 
 """
@@ -79,3 +81,5 @@ function unpack(packed_array::AbstractArray{<:Any,N}, packed_shapes, pattern::Pa
     end
     return unpacked_arrays
 end
+
+unpack(packed_array, packed_shapes, ::Val{T}) where T = unpack(packed_array, packed_shapes, T)

--- a/src/parse_shape.jl
+++ b/src/parse_shape.jl
@@ -32,7 +32,7 @@ julia> parse_shape(rand(2,3,4), (:a, :b, -))
 julia> parse_shape(rand(2,3), (-, -))
 NamedTuple()
 
-julia> parse_shape(rand(2,3,4,5), (:first, :second, :third, :fourth))
+julia> parse_shape(rand(2,3,4,5), einops"first second third fourth")
 (first = 2, second = 3, third = 4, fourth = 5)
 
 julia> parse_shape(rand(2,3,4), Val((:a, :b, ..)))

--- a/src/parse_shape.jl
+++ b/src/parse_shape.jl
@@ -21,7 +21,7 @@ and `-` to ignore dimensions, and `...` to ignore any number of dimensions.
 
 !!! note
     For proper type inference, the pattern needs to be passed as `Val(pattern)`
-    when an ellipsis is present.
+    when an ellipsis is present. This is done automatically when using [`@einops_str`](@ref).
 
 # Examples
 

--- a/src/patterns/ellipses.jl
+++ b/src/patterns/ellipses.jl
@@ -3,7 +3,7 @@ function ellipsis_replacement(side, N)
     return anonymous_symbols(:__ellipsis, N - length(side) + 1)
 end
 
-@generated function replace_ellipses(::ArrowPattern{left,right}, ::Val{N}) where {left,right,N}
+function replace_ellipses(left, right, N)
     if (..) ∈ flatten(left)
         (..) ∉ left && throw("Ellipsis is not allowed to be nested on left side.")
     else
@@ -26,7 +26,7 @@ end
     else
         right
     end
-    :($(new_left --> new_right))
+    new_left, new_right
 end
 
 @generated function replace_ellipses_einsum(::ArrowPattern{left,right}, ::Val{Ns}) where {left,right,Ns}

--- a/src/patterns/parse.jl
+++ b/src/patterns/parse.jl
@@ -64,4 +64,4 @@ end
 const SpecialToken = Dict(:* => (*), :_ => (-), :... => (..))
 get_special_token(symbol) = get(SpecialToken, symbol, symbol)
 mapfilter(f, pred, xs) = map(f, filter(pred, xs))
-tokenize_generic(pattern) = Tuple(mapfilter(get_special_token ∘ Symbol, !isempty, split(pattern, ' ')))
+tokenize_generic(pattern) = Val(Tuple(mapfilter(get_special_token ∘ Symbol, !isempty, split(pattern, ' '))))

--- a/src/patterns/patterns.jl
+++ b/src/patterns/patterns.jl
@@ -83,10 +83,10 @@ julia> einops"i j, j k -> i k" # for einsum
 ((:i, :j), (:j, :k)) --> (:i, :k)
 
 julia> einops"a b _ d" # for parse_shape
-(:a, :b, -, :d)
+Val{(:a, :b, -, :d)}()
 
 julia> einops"i j * k" # for pack/unpack
-(:i, :j, *, :k)
+Val{(:i, :j, *, :k)}()
 ```
 """
 macro einops_str(pattern)

--- a/src/patterns/utils.jl
+++ b/src/patterns/utils.jl
@@ -12,19 +12,15 @@ function extract(T::Type, input_tuple::Tuple)
     return (instances_from_first..., extract(T, rest_elements)...)
 end
 
-
-@generated function anonymous_symbols(::Val{prefix}, ::Val{N}) where {prefix,N}
-    ex = :(())
+function anonymous_symbols(prefix, N)
+    symbols = []
     for i in 1:N
-        ex = :((($ex)..., $(:(Symbol(:($prefix), '_', $i)))))
+        push!(symbols, Symbol("$(prefix)_$i"))
     end
-    ex
+    return Tuple(symbols)
 end
 
-anonymous_symbols(prefix::Symbol, n::Int) = anonymous_symbols(Val(prefix), Val(n))
-
-
-@generated function remove_anonymous_dims(::Val{side}) where side
+function remove_anonymous_dims(side)
     integers = filter(!isone, extract(Integer, side))
     symbols = anonymous_symbols(:__anon_dim, length(integers))
     context = NamedTuple{symbols}(integers)
@@ -43,7 +39,5 @@ anonymous_symbols(prefix::Symbol, n::Int) = anonymous_symbols(Val(prefix), Val(n
             t
         end
     end
-    :($new_side, $context)
+    return new_side, context
 end
-
-remove_anonymous_dims(side) = remove_anonymous_dims(Val(side))

--- a/src/repeat.jl
+++ b/src/repeat.jl
@@ -1,8 +1,14 @@
-_get(x, i::Int) = x[i]
-_get(x, ::Nothing) = 1
-function prerepeat_shape(input_shape::Dims, left::Tuple{Vararg{Symbol}}, right::NTuple{N,Symbol}) where N
-    output_shape = map(key -> _get(input_shape, findfirst(isequal(key), left)), right)
-    return ntuple(i -> output_shape[i], length(right))
+function reshape_pre_repeat(N, positions)
+    new_shape = Expr(:tuple, [:(size(x, $i)) for i in 1:N]...)
+    sizes = new_shape.args
+    for i in sort(collect(positions))
+        if i > length(sizes)
+            append!(sizes, ones(Int, i - length(sizes)))
+        else
+            insert!(sizes, i, 1)
+        end
+    end
+    return new_shape
 end
 
 """
@@ -32,28 +38,31 @@ julia> z == reshape(repeat(x, 1,1,2), 2,6)
 true
 ```
 """
-function Base.repeat(x::AbstractArray, (left, right)::ArrowPattern; context...)
+@generated function Base.repeat(x::AbstractArray{<:Any,N}, ::ArrowPattern{L,R}; context...) where {N,L,R}
+    @nospecialize x
+    left, right = replace_ellipses(L, R, N)
     right, extra_context = remove_anonymous_dims(right)
-    context = merge(NamedTuple(context), extra_context)
-    left, right = replace_ellipses(left --> right, Val(ndims(x)))
     left_names, right_names = extract(Symbol, left), extract(Symbol, right)
-    context_info, permutation, repeats::NTuple{length(right_names),Int} = @ignore_derivatives begin
-        repeat_dim_names = setdiff(right_names, left_names)
-        context_repeat = NamedTuple(d => context[d] for d in repeat_dim_names)
-        info_dim_names = setdiff(keys(context), repeat_dim_names)
-        context_info = NamedTuple(d => context[d] for d in info_dim_names)
-        isempty(setdiff(right_names, left_names, keys(context))) || throw(ArgumentError("Unknown dimension sizes: $(setdiff(right_names, left_names))"))
-        right_names_no_repeat = setdiff(right_names, repeat_dim_names)
-        permutation = permutation_mapping(left_names, ntuple(i -> right_names_no_repeat[i], length(left_names)))
-        repeats = ntuple(i -> get(context_repeat, right_names[i], 1), length(right_names))
-        context_info, permutation, repeats
+    repeat_names = setdiff(right_names, left_names)
+    right_names_no_repeat = setdiff(right_names, repeat_names)
+    permutation = get_permutation(left_names, right_names_no_repeat)
+    positions = get_mapping(right_names, repeat_names)
+    repeats = [:(context[$(QuoteNode(name))]) for name in repeat_names]
+    repeat_dims = [i in positions ? repeats[findfirst(==(i), positions)] : 1 for i in 1:maximum(positions; init=0)]
+    context_expr = !isempty(extra_context) && :(context = pairs(merge(NamedTuple(context), $extra_context)))
+    permute_expr = permutation !== ntuple(identity, length(permutation)) && :(x = _permutedims(x, $permutation))
+    repeat_expr = !all(==(1), repeat_dims) && quote
+        x = reshape(x, $(reshape_pre_repeat(length(left_names), positions)))
+        x = repeat(x, $(repeat_dims...))
     end
-    expanded = reshape_in(x, left; context_info...)
-    permuted = _permutedims(expanded, permutation)
-    reshaped = reshape(permuted, prerepeat_shape(size(expanded), left_names, right_names))
-    repeated = all(isone, repeats) ? reshaped : repeat(reshaped, repeats...)
-    collapsed = reshape_out(repeated, right)
-    return collapsed
+    quote
+        $context_expr
+        x = reshape(x, $(reshape_in(N, left, pairs_type_to_names(context)))) # extra context not needed
+        $permute_expr
+        $repeat_expr
+        x = reshape(x, $(reshape_out(right)))
+        return x
+    end
 end
 
 Base.repeat(x::AbstractArray{<:AbstractArray}, pattern::ArrowPattern; context...) = repeat(stack(x), pattern; context...)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -59,8 +59,4 @@ end
 
 # fix for 1.10:
 _permutedims(x::AbstractArray{T,0}, ::Tuple{}) where T = x
-
-function _permutedims(x, perm::NTuple{N,Int}) where N
-    perm === ntuple(identity, N) && return x
-    permutedims(x, perm)
-end
+_permutedims(x, perm::NTuple{N,Int}) where N = permutedims(x, perm)

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,62 +1,61 @@
-function reshape_in(x, left; context...)
-    length(left) == ndims(x) || throw(ArgumentError("Input length $(length(left)) does not match number of dimensions $(ndims(x))"))
+struct NoReshape end
+
+Base.reshape(x, ::Type{NoReshape}) = x
+
+pairs_type_to_names(::Type{<:Base.Pairs{Symbol,<:Any,<:Any,<:NamedTuple{names}}}) where names = names
+
+function reshape_in(N, left, context_names)
+    length(left) == N || throw(ArgumentError("Input length $(length(left)) does not match array dimensionality $N"))
     allunique(extract(Symbol, left)) || throw(ArgumentError("Left names $(left) are not unique"))
-    new_shape = @ignore_derivatives begin
-        new_shape = Int[]
-        for (i, input_dim) in enumerate(left)
-            if input_dim isa Int
-                input_dim == 1 || throw(ArgumentError("Singleton dimension size is not 1: $input_dim"))
-                continue
-            elseif input_dim isa Symbol
-                push!(new_shape, size(x, i))
-            elseif input_dim isa Tuple{Vararg{Symbol}}
-                known_size = filter(name -> haskey(context, name), input_dim)
-                length(input_dim) - length(known_size) <= 1 || throw(ArgumentError("Unknown dimension sizes: $(filter(name -> !haskey(context, name), input_dim))"))
-                known_size_prod = prod(context[name] for name in known_size)
-                new_dim_size = (name in known_size ? context[name] : size(x, i) ÷ known_size_prod for name in input_dim)
-                push!(new_shape, new_dim_size...)
-            else
-                throw(ArgumentError("Invalid input dimension: $input_dim"))
-            end
+    left isa Tuple{Vararg{Symbol}} && return NoReshape
+    new_shape = :()
+    sizes = new_shape.args
+    for (i, input_dim) in enumerate(left)
+        if input_dim isa Int
+            input_dim == 1 || throw(ArgumentError("Singleton dimension size is not 1: $input_dim"))
+            continue
+        elseif input_dim isa Symbol
+            push!(sizes, :(size(x, $i)))
+        elseif input_dim isa Tuple{Vararg{Symbol}}
+            known_size = filter(in(context_names), input_dim)
+            length(input_dim) - length(known_size) <= 1 || throw(ArgumentError("Unknown dimension sizes: $(filter(∉(context_names), input_dim))"))
+            unknown_size = Expr(:call, :*, (:(context[$(QuoteNode(name))]) for name in known_size)...)
+            new_dim_size = Tuple(name in known_size ? :(context[$(QuoteNode(name))]) : :(size(x, $i) ÷ $unknown_size) for name in input_dim)
+            push!(sizes, new_dim_size...)
+        else
+            throw(ArgumentError("Invalid input dimension: $input_dim"))
         end
-        new_shape
     end
-    return reshape(x, ntuple(i -> new_shape[i]::Int, length(extract(Symbol, left))))
+    return new_shape
 end
 
-reshape_in(x, ::Tuple{Vararg{Symbol}}; context...) = x
+get_mapping(left, right) = Tuple(findfirst.(isequal.(right), (left,)))
 
-
-function permutation_mapping(left::NTuple{N,T}, right::NTuple{N,T}) where {N,T}
-    perm::Vector{Int} = findfirst.(isequal.([right...]), Ref([left...]))
-    return ntuple(i -> perm[i], Val(N))
+function get_permutation(left, right)
+    isempty(setdiff(left, right)) || throw(ArgumentError("Set of left names $(left) does not match set of right names $(right)"))
+    return get_mapping(left, right)
 end
 
-# TODO: static `TransmuteDims.transmutedims` using type parameters of `ArrowPattern`
-function permute(x, left, right)
-    left_names, right_names = extract(Symbol, left), extract(Symbol, right)
-    @ignore_derivatives isempty(setdiff(left_names, right_names)) || throw(ArgumentError("Set of left names $(left_names) does not match set of right names $(right_names)"))
-    allunique(left_names) || throw(ArgumentError("Left names $(left_names) are not unique"))
-    allunique(right_names) || throw(ArgumentError("Right names $(right_names) are not unique"))
-    perm = permutation_mapping(left_names, right_names)
-    return _permutedims(x, perm)
-end
-
-
-# TODO: statically remove if no singleton/tuple dimensions
-len(dim::Tuple{Vararg{Symbol}}) = length(dim)
-len(::Symbol) = 1
-len(x::Int) = x == 1 ? 0 : throw(ArgumentError("Singleton dimension size is not 1: $x"))
-
-function reshape_out(x, right)
+function reshape_out(right)
     allunique(extract(Symbol, right)) || throw(ArgumentError("Right names $(right) are not unique"))
-    size_iter = Iterators.Stateful(size(x))
-    shape = @ignore_derivatives Int[prod(Iterators.take(size_iter, len(dim)); init=1) for dim in right]
-    return reshape(x, ntuple(i -> shape[i], length(right)))
+    right isa Tuple{Vararg{Symbol}} && return NoReshape
+    new_shape = :()
+    sizes = new_shape.args
+    i = 1
+    for dim in right
+        if dim isa Int
+            dim == 1 || throw(ArgumentError("Singleton dimension size is not 1: $dim"))
+            push!(sizes, dim)
+        elseif dim isa Symbol
+            push!(sizes, :(size(x, $i)))
+            i += 1
+        elseif dim isa Tuple{Vararg{Symbol}}
+            push!(sizes, isempty(dim) ? 1 : Expr(:call, :*, (:(size(x, $i)) for i in i:i+length(dim)-1)...))
+            i += length(dim)
+        end
+    end
+    return new_shape
 end
-
-reshape_out(x, ::Tuple{Vararg{Symbol}}) = x
-
 
 # fix for 1.10:
 _permutedims(x::AbstractArray{T,0}, ::Tuple{}) where T = x

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -35,8 +35,8 @@ using Test
 
     @testset "String Pattern Parsing" begin
         @testset "basic patterns" begin
-            @test einops"a _ c" == (:a, -, :c)
-            @test einops"_ _ _" == (-, -, -)
+            @test einops"a _ c" == Val((:a, -, :c))
+            @test einops"_ _ _" == Val((-, -, -))
         end
 
         @testset "arrow patterns" begin
@@ -60,11 +60,11 @@ using Test
         end
 
         @testset "pack/unpack patterns" begin
-            @test einops"i j * k" == (:i, :j, *, :k)
-            @test einops" i  j  *  k " == (:i, :j, *, :k)
-            @test einops"* i" == (*, :i)
-            @test einops"i *" == (:i, *)
-            @test einops"i i" == (:i, :i)
+            @test einops"i j * k" == Val((:i, :j, *, :k))
+            @test einops" i  j  *  k " == Val((:i, :j, *, :k))
+            @test einops"* i" == Val((*, :i))
+            @test einops"i *" == Val((:i, *))
+            @test einops"i i" == Val((:i, :i))
         end
 
         @testset "parsing errors" begin


### PR DESCRIPTION
Basically achieves zero overhead by using `@generated` for functions at the API level instead of helper function level.

Also closes #25