### PR TITLE
Optimize einsum contraction order

### DIFF
--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -3,7 +3,7 @@ module Einops
 using EllipsisNotation; export ..
 using TupleTools: flatten, insertat
 using ChainRulesCore: @ignore_derivatives
-using OMEinsum: StaticEinCode, optimize_code, TreeSA
+using OMEinsum: OMEinsum
 
 include("utils.jl")
 

--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -3,7 +3,7 @@ module Einops
 using EllipsisNotation; export ..
 using TupleTools: flatten, insertat
 using ChainRulesCore: @ignore_derivatives
-using OMEinsum: StaticEinCode
+using OMEinsum: StaticEinCode, optimize_code, TreeSA
 
 include("utils.jl")
 

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -7,7 +7,7 @@ function get_size_dict(arrays, indices)
 end
 
 """
-    einsum(arrays..., (left --> right))
+    einsum(arrays..., pattern; optimizer=OMEinsum.GreedyMethod())
 
 Compute the einsum operation specified by the pattern.
 
@@ -22,7 +22,7 @@ true
 """
 function einsum(
     args::Vararg{Union{AbstractArray,ArrowPattern{L,R}}};
-    optimizer::OMEinsum.Optimizer = OMEinsum.TreeSA()
+    optimizer::OMEinsum.CodeOptimizer = OMEinsum.GreedyMethod()
 ) where {L,R}
     arrays::Tuple{Vararg{AbstractArray}} = Base.front(args)
     last(args)::ArrowPattern

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -1,6 +1,11 @@
 nested(x::Tuple) = (x,)
 nested(x::Tuple{Vararg{Tuple}}) = x
 
+function get_size_dict(arrays, indices::Tuple{Vararg{Tuple{Vararg{Symbol}}}})
+    size_named_tuple = merge(parse_shape.(arrays, indices)...)
+    return Dict(zip(keys(size_named_tuple), values(size_named_tuple)))
+end
+
 """
     einsum(arrays..., (left --> right))
 
@@ -15,9 +20,13 @@ julia> einsum(x, y, ((:i, :j), (:j, :k)) --> (:i, :k)) == x * y
 true
 ```
 """
-function einsum(args::Vararg{Union{AbstractArray,ArrowPattern{L,R}}}) where {L,R}
+function einsum(args::Vararg{Union{AbstractArray,ArrowPattern{L,R}}}; optimizer=TreeSA()) where {L,R}
     arrays::Tuple{Vararg{AbstractArray}} = Base.front(args)
     last(args)::ArrowPattern
-    L′, R′ = @ignore_derivatives replace_ellipses_einsum(nested(L) --> R, Val(ndims.(arrays)))
-    return StaticEinCode{Symbol,L′,R′}()(arrays...)
+    optimized_code = @ignore_derivatives begin
+        L′, R′ = replace_ellipses_einsum(nested(L) --> R, Val(ndims.(arrays)))
+        code = StaticEinCode{Symbol,L′,R′}()
+        optimized_code = optimize_code(code, get_size_dict(arrays, L′), optimizer)
+    end
+    return optimized_code(arrays...)
 end


### PR DESCRIPTION
Since `einsum` isn't a generated function, and the `OMEinsum` backend is mostly not type stable anyway (https://github.com/under-Peter/OMEinsum.jl/issues/97), array sizes are known. This PR is meant to allow einsum contraction order optimization. I don't know exactly what sets `TreeSA` and the different optimizers apart, and I don't know if I'd like them to be user-facing here. Related is #26.

Closes #24 