### PR TITLE
Add parenthesis support in `einsum`

### DIFF
--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -16,8 +16,6 @@ export parse_shape
 
 include("rearrange.jl")
 export rearrange
-export expand
-export collapse
 
 include("reduce.jl")
 export reduce

--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -16,6 +16,8 @@ export parse_shape
 
 include("rearrange.jl")
 export rearrange
+export expand
+export collapse
 
 include("reduce.jl")
 export reduce

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -19,20 +19,6 @@ function omeinsum_indices(L′, R′)
     return L_ome, R_ome
 end
 
-"""
-    einsum(arrays..., pattern; optimizer=OMEinsum.GreedyMethod())
-
-Compute the einsum operation specified by the pattern.
-
-# Examples
-
-```jldoctest
-julia> x, y = rand(2,3), rand(3,4);
-
-julia> einsum(x, y, ((:i, :j), (:j, :k)) --> (:i, :k)) == x * y
-true
-```
-"""
 function _einsum(
     ::ArrowPattern{L,R}, arrays::Vararg{AbstractArray};
     optimizer::OMEinsum.CodeOptimizer = OMEinsum.GreedyMethod(),
@@ -52,6 +38,20 @@ function _einsum(
     return collapse(output, Val(R); context...)
 end
 
+"""
+    einsum(arrays..., pattern; optimizer=OMEinsum.GreedyMethod())
+
+Compute the einsum operation specified by the pattern.
+
+# Examples
+
+```jldoctest
+julia> x, y = rand(2,3), rand(3,4);
+
+julia> einsum(x, y, ((:i, :j), (:j, :k)) --> (:i, :k)) == x * y
+true
+```
+"""
 function einsum(args::Vararg{Union{AbstractArray,ArrowPattern}}; kws...)
     arrays::Tuple{Vararg{AbstractArray}} = Base.front(args)
     pattern = last(args)::ArrowPattern

--- a/src/einsum.jl
+++ b/src/einsum.jl
@@ -1,5 +1,6 @@
 nested(x::Tuple) = (x,)
 nested(x::Tuple{Vararg{Tuple}}) = x
+nested_val(::Val{x}) where x = Val.(nested(x))
 
 function get_size_dict(arrays, indices)
     size_named_tuple = merge(parse_shape.(arrays, Val.(indices))...)
@@ -22,14 +23,29 @@ true
 """
 function einsum(
     args::Vararg{Union{AbstractArray,ArrowPattern{L,R}}};
-    optimizer::OMEinsum.CodeOptimizer = OMEinsum.GreedyMethod()
+    optimizer::OMEinsum.CodeOptimizer = OMEinsum.GreedyMethod(),
+    context...
 ) where {L,R}
     arrays::Tuple{Vararg{AbstractArray}} = Base.front(args)
     last(args)::ArrowPattern
+    # Replace ellipses in nested patterns using per-array ranks
+    L′, R′ = @ignore_derivatives replace_ellipses_einsum(nested(L) --> R, Val(ndims.(arrays)))
+    # Expand arrays according to possibly nested left indices
+    arrays = expand.(arrays, nested_val(Val(L)); context...)
+    # Flatten indices for OMEinsum (it does not understand nested tuples)
+    L_flat = Tuple(map(flatten, L′))
+    R_flat = flatten(R′)
+    # Remove singleton literals (1) from index lists for OMEinsum, which expects only Symbols
+    L_ome = Tuple(begin
+        any(x -> x isa Int && x != 1, li) && throw(ArgumentError("Only singleton integer dimensions (1) are allowed in left indices: $li"))
+        Tuple(e for e in li if e isa Symbol)
+    end for li in L_flat)
+    any(x -> x isa Int && x != 1, R_flat) && throw(ArgumentError("Only singleton integer dimensions (1) are allowed in right indices: $R_flat"))
+    R_ome = Tuple(e for e in R_flat if e isa Symbol)
     optimized_code = @ignore_derivatives begin
-        L′, R′ = replace_ellipses_einsum(nested(L) --> R, Val(ndims.(arrays)))
-        code = OMEinsum.StaticEinCode{Symbol,L′,R′}()
-        optimized_code = OMEinsum.optimize_code(code, get_size_dict(arrays, L′), optimizer)
+        code = OMEinsum.StaticEinCode{Symbol,L_ome,R_ome}()
+        OMEinsum.optimize_code(code, get_size_dict(arrays, L_ome), optimizer)
     end
-    return optimized_code(arrays...)
+    output = optimized_code(arrays...)
+    return collapse(output, Val(R); context...)
 end

--- a/src/patterns/parse.jl
+++ b/src/patterns/parse.jl
@@ -64,4 +64,13 @@ end
 const SpecialToken = Dict(:* => (*), :_ => (-), :... => (..))
 get_special_token(symbol) = get(SpecialToken, symbol, symbol)
 mapfilter(f, pred, xs) = map(f, filter(pred, xs))
-tokenize_generic(pattern) = Val(Tuple(mapfilter(get_special_token ∘ Symbol, !isempty, split(pattern, ' '))))
+
+# Recursively map special tokens inside possibly nested tuples
+map_special_tokens(x) = x
+map_special_tokens(x::Symbol) = get_special_token(x)
+map_special_tokens(x::Tuple) = Tuple(map(map_special_tokens, x))
+
+# Generic patterns (no arrow) should still honor parentheses and commas,
+# producing nested tuples where appropriate. Reuse the side tokenizer and
+# then map special tokens like `_`, `*`, and `...`.
+tokenize_generic(pattern) = Val(map_special_tokens(tokenize_side(pattern)))

--- a/src/rearrange.jl
+++ b/src/rearrange.jl
@@ -43,3 +43,45 @@ end
 
 rearrange(x::AbstractArray{<:AbstractArray}, pattern::ArrowPattern; context...) = rearrange(stack(x), pattern; context...)
 rearrange(x, pattern::ArrowPattern; context...) = rearrange(stack(x), pattern; context...)
+
+@generated function expand(x::AbstractArray{<:Any,N}, ::Val{L}; context...) where {N,L}
+    left = replace_ellipses_left(L, N)
+    shape_in = get_shape_in(N, left, pairs_type_to_names(context))
+    quote
+        $(isnothing(shape_in) || :(x = reshape(x, $shape_in)))
+        return x
+    end
+end
+
+@generated function collapse(x::AbstractArray{<:Any,N}, ::Val{R}; context...) where {N,R}
+    # Replace ellipsis on the right side using available rank information N.
+    # Number of consumed dimensions on the right equals the number of symbols.
+    right = begin
+        # Count symbol dimensions (they consume axes); integers don't consume axes
+        symbol_count = length(extract(Symbol, R))
+        if (..) ∈ flatten(R)
+            # Allow only a single ellipsis
+            count(==(..), flatten(R)) <= 1 || throw("Only one ellipsis is allowed: $R")
+            # Ellipsis must stand for the remaining axes
+            m = N - symbol_count
+            m >= 0 || throw("Ellipsis represents a negative number of dimensions: $R with N=$N")
+            replacement = anonymous_symbols(:__ellipsis, m)
+            if (..) in R
+                insertat(R, only(findfirst(==(..), R)), replacement)
+            else
+                # ellipsis is in a nested tuple
+                i = findfirst(t -> t isa Tuple && (..) in t, R)
+                t = R[i]
+                j = findfirst(==(..), t)
+                insertat(R, i, (insertat(t, j, replacement),))
+            end
+        else
+            R
+        end
+    end
+    shape_out = get_shape_out(right)
+    quote
+        $(isnothing(shape_out) || :(x = reshape(x, $shape_out)))
+        return x
+    end
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,8 +1,8 @@
 pairs_type_to_names(::Type{<:Base.Pairs{Symbol,<:Any,<:Any,<:NamedTuple{names}}}) where names = names
 
-function get_shape_in(N, left, context_names)
+function get_shape_in(N, left, context_names; allow_repeats=false)
     length(left) == N || throw(ArgumentError("Input length $(length(left)) does not match array dimensionality $N"))
-    allunique(extract(Symbol, left)) || throw(ArgumentError("Left names $(left) are not unique"))
+    allunique(extract(Symbol, left)) || allow_repeats || throw(ArgumentError("Left names $(left) are not unique"))
     left isa Tuple{Vararg{Symbol}} && return nothing
     new_shape = :()
     sizes = new_shape.args


### PR DESCRIPTION
Would help make some operations involving `einsum` more concise, e.g.

```julia
einsum(W, x, einops"s2 s1 k, (s1 k) ... -> (s2 k) ...")
```

Exporting `expand` and `collapse` isn't necessary for this, but they might be helpful, even if they're just edge cases of `rearrange` with less redundancy.

Closes #39 