### PR TITLE
Support `String` patterns

### DIFF
--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -29,4 +29,6 @@ export einsum
 include("pack_unpack.jl")
 export pack, unpack
 
+include("String.jl")
+
 end

--- a/src/String.jl
+++ b/src/String.jl
@@ -1,0 +1,26 @@
+const warn_str = "Einops supports `Base.String` patterns for Einops-native functions only for convenience, as using them is type unstable."
+
+function parse_shape(x, pattern::String) 
+    Base.depwarn(warn_str, :parse_shape)
+    return parse_shape(x, parse_pattern(pattern))
+end
+
+function rearrange(x, pattern::String; context...)
+    Base.depwarn(warn_str, :rearrange)
+    rearrange(x, parse_pattern(pattern); context...)
+end
+
+function _einsum(pattern::String, arrays...; kws...)
+    Base.depwarn(warn_str, :_einsum)
+    _einsum(parse_pattern(pattern), arrays...; kws...)
+end
+
+function pack(x, pattern::String)
+    Base.depwarn(warn_str, :pack)
+    return pack(x, parse_pattern(pattern))
+end
+
+function unpack(x, ps, pattern::String)
+    Base.depwarn(warn_str, :unpack)
+    return unpack(x, ps, parse_pattern(pattern))
+end


### PR DESCRIPTION
Currently has deprecation warnings to warn when these are actually used. It's only shown when running Julia with `--depwarn=yes` though. Might need to pass `force=true` since people are most likely to use it in REPL, or accidentally in source code.

Closes #42