### PR TITLE
Add public macro interface

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,16 @@
 name = "Einops"
 uuid = "e3ce28c8-8bfb-4704-8add-e3e7f14b55c9"
 version = "0.1.14"
-authors = ["Anton Oresten <antonoresten@gmail.com> and contributors"]
+authors = ["Anton Oresten <antonoresten@gmail.com>"]
+
+[workspace]
+projects = ["test", "docs"]
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 EllipsisNotation = "da5c29d0-fa7d-589e-88eb-ea29b0a81949"
 OMEinsum = "ebe7aa44-baf0-506c-a96f-8464559b3922"
+Republic = "27243419-9dde-4721-b67c-fd63626fea7f"
 Rewrap = "e37f04ce-ca06-4a96-b09f-ea39bec02b08"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 
@@ -14,6 +18,7 @@ TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
 ChainRulesCore = "1.7"
 EllipsisNotation = "1"
 OMEinsum = "0.8, 0.9"
+Republic = "2.2.0"
 Rewrap = "0.1.1"
 TupleTools = "1"
 julia = "1.9"

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -3,7 +3,7 @@
 ## Patterns
 
 ```@docs
-ArrowPattern
+Einops.ArrowPattern
 -->
 @einops_str
 ..

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,30 +19,35 @@ parse_shape
 
 ```@docs
 rearrange
+@rearrange
 ```
 
 ## `reshape`
 
 ```@docs
 reshape
+@reshape
 ```
 
 ## `reduce`
 
 ```@docs
 reduce
+@reduce
 ```
 
 ## `repeat`
 
 ```@docs
 repeat
+@repeat
 ```
 
 ## `einsum`
 
 ```@docs
 einsum
+@einsum
 ```
 
 ## `pack` and `unpack`

--- a/docs/src/api.md
+++ b/docs/src/api.md
@@ -19,35 +19,35 @@ parse_shape
 
 ```@docs
 rearrange
-@rearrange
+Einops.@rearrange
 ```
 
 ## `reshape`
 
 ```@docs
 reshape
-@reshape
+Einops.@reshape
 ```
 
 ## `reduce`
 
 ```@docs
 reduce
-@reduce
+Einops.@reduce
 ```
 
 ## `repeat`
 
 ```@docs
 repeat
-@repeat
+Einops.@repeat
 ```
 
 ## `einsum`
 
 ```@docs
 einsum
-@einsum
+Einops.@einsum
 ```
 
 ## `pack` and `unpack`

--- a/src/Einops.jl
+++ b/src/Einops.jl
@@ -1,5 +1,7 @@
 module Einops
 
+using Republic: @public
+
 import Base: reshape, reduce, repeat
 
 using EllipsisNotation; export ..
@@ -12,8 +14,8 @@ using Rewrap: Permute, Reduce, Repeat
 include("utils.jl")
 
 include("patterns/patterns.jl")
-export ArrowPattern, -->
-export @einops_str
+@public ArrowPattern
+export -->, @einops_str
 
 include("parse_shape.jl")
 export parse_shape
@@ -35,5 +37,8 @@ export einsum
 
 include("pack_unpack.jl")
 export pack, unpack
+
+include("macros.jl")
+@public @rearrange, @reshape, @reduce, @repeat, @einsum
 
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -35,7 +35,21 @@ function einops_macro_call(f::Symbol, args)
     return call
 end
 
-_to_kw(kw) = Expr(:kw, kw.args[1], esc(kw.args[2]))
+# Normalize a single keyword entry for forwarding into the generated call's
+# `:parameters` block. Entries can take any of the standard Julia forms:
+#   `k = v` / `k => v` (`:(=)` or `:kw`), the `; k` shorthand (a bare `Symbol`),
+#   or a `; kws...` splat (`:...`). Only values are escaped; key names are not.
+function _to_kw(kw)
+    if kw isa Symbol
+        return Expr(:kw, kw, esc(kw))           # `; k`  ==>  `k = k`
+    elseif Meta.isexpr(kw, :...)
+        return Expr(:..., esc(kw.args[1]))       # `; kws...`
+    elseif Meta.isexpr(kw, (:kw, :(=)), 2)
+        return Expr(:kw, kw.args[1], esc(kw.args[2]))
+    else
+        return esc(kw)
+    end
+end
 
 """
     @rearrange(x, "pattern", context...)

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -36,19 +36,14 @@ function einops_macro_call(f::Symbol, args)
 end
 
 # Normalize a single keyword entry for forwarding into the generated call's
-# `:parameters` block. Entries can take any of the standard Julia forms:
-#   `k = v` / `k => v` (`:(=)` or `:kw`), the `; k` shorthand (a bare `Symbol`),
-#   or a `; kws...` splat (`:...`). Only values are escaped; key names are not.
+# `:parameters` block. The parser only ever emits one of three forms here:
+#   the `; k` shorthand (a bare `Symbol`), a `; kws...` splat (`:...`), or an
+#   explicit `k = v` (`:kw` from `; k=v`, or `:(=)` from a trailing `, k=v`).
+# Only values are escaped; key names are not.
 function _to_kw(kw)
-    if kw isa Symbol
-        return Expr(:kw, kw, esc(kw))           # `; k`  ==>  `k = k`
-    elseif Meta.isexpr(kw, :...)
-        return Expr(:..., esc(kw.args[1]))       # `; kws...`
-    elseif Meta.isexpr(kw, (:kw, :(=)), 2)
-        return Expr(:kw, kw.args[1], esc(kw.args[2]))
-    else
-        return esc(kw)
-    end
+    kw isa Symbol && return Expr(:kw, kw, esc(kw))          # `; k`  ==>  `k = k`
+    Meta.isexpr(kw, :...) && return Expr(:..., esc(kw.args[1]))  # `; kws...`
+    return Expr(:kw, kw.args[1], esc(kw.args[2]))           # `k = v`
 end
 
 """

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,0 +1,143 @@
+# Shorthand macros that let a pattern be written as a plain string literal
+# instead of `einops"..."`. Each `@f(args...)` expands to `f(args...)` with the
+# single string-literal argument replaced by its parsed pattern, so e.g.
+#
+#     @rearrange(x, "a b -> b a", k=1)   ==>   rearrange(x, (:a, :b) --> (:b, :a); k=1)
+#
+# The string can sit anywhere among the positional arguments, which is why the
+# same helper works for `einsum` (pattern last) as for `rearrange` (pattern
+# second) or `reduce` (pattern third).
+
+function einops_macro_call(f::Symbol, args)
+    positional = Any[]
+    kwargs = Any[]
+    found = false
+    for a in args
+        if Meta.isexpr(a, :parameters)
+            # keyword arguments passed after `;`
+            for kw in a.args
+                push!(kwargs, _to_kw(kw))
+            end
+        elseif Meta.isexpr(a, :(=))
+            push!(kwargs, _to_kw(a))
+        elseif a isa AbstractString
+            found && throw(ArgumentError("@$f expects a single string pattern argument"))
+            found = true
+            push!(positional, parse_pattern(a))
+        else
+            push!(positional, esc(a))
+        end
+    end
+    found || throw(ArgumentError("@$f expects a string pattern argument"))
+    call = Expr(:call, GlobalRef(@__MODULE__, f))
+    isempty(kwargs) || push!(call.args, Expr(:parameters, kwargs...))
+    append!(call.args, positional)
+    return call
+end
+
+_to_kw(kw) = Expr(:kw, kw.args[1], esc(kw.args[2]))
+
+"""
+    @rearrange(x, "pattern", context...)
+
+Shorthand for [`rearrange`](@ref) that takes the pattern as a string literal
+instead of `einops"..."`.
+
+# Examples
+
+```jldoctest
+julia> using Einops: @rearrange
+
+julia> x = rand(2, 3, 5);
+
+julia> @rearrange(x, "a b c -> c b a") == rearrange(x, einops"a b c -> c b a")
+true
+```
+"""
+macro rearrange(args...)
+    einops_macro_call(:rearrange, args)
+end
+
+"""
+    @reshape(x, "pattern", context...)
+
+Shorthand for [`reshape`](@ref) that takes the pattern as a string literal
+instead of `einops"..."`.
+
+# Examples
+
+```jldoctest
+julia> using Einops: @reshape
+
+julia> x = rand(2, 3);
+
+julia> @reshape(x, "a b -> (a b)") == reshape(x, einops"a b -> (a b)")
+true
+```
+"""
+macro reshape(args...)
+    einops_macro_call(:reshape, args)
+end
+
+"""
+    @reduce(f, x, "pattern", context...)
+
+Shorthand for [`reduce`](@ref) that takes the pattern as a string literal
+instead of `einops"..."`.
+
+# Examples
+
+```jldoctest
+julia> using Einops: @reduce
+
+julia> x = rand(2, 3);
+
+julia> @reduce(sum, x, "a b -> a") == reduce(sum, x, einops"a b -> a")
+true
+```
+"""
+macro reduce(args...)
+    einops_macro_call(:reduce, args)
+end
+
+"""
+    @repeat(x, "pattern", context...)
+
+Shorthand for [`repeat`](@ref) that takes the pattern as a string literal
+instead of `einops"..."`.
+
+# Examples
+
+```jldoctest
+julia> using Einops: @repeat
+
+julia> x = rand(2, 3);
+
+julia> @repeat(x, "a b -> a b c", c=4) == repeat(x, einops"a b -> a b c", c=4)
+true
+```
+"""
+macro repeat(args...)
+    einops_macro_call(:repeat, args)
+end
+
+"""
+    @einsum(arrays..., "pattern", context...)
+
+Shorthand for [`einsum`](@ref) that takes the pattern as a string literal
+instead of `einops"..."`.
+
+# Examples
+
+```jldoctest
+julia> using Einops: @einsum
+
+julia> x, y = rand(2, 3), rand(3, 4);
+
+julia> @einsum(x, y, "i j, j k -> i k") == einsum(x, y, einops"i j, j k -> i k")
+true
+```
+"""
+macro einsum(args...)
+    einops_macro_call(:einsum, args)
+end

--- a/src/patterns/patterns.jl
+++ b/src/patterns/patterns.jl
@@ -55,13 +55,13 @@ julia> pattern1 = (:a, :b, :c) --> (:c, (:b, :a)) # nested tuple
 (:a, :b, :c) --> (:c, (:b, :a))
 
 julia> typeof(pattern1)
-ArrowPattern{(:a, :b, :c), (:c, (:b, :a))}
+Einops.ArrowPattern{(:a, :b, :c), (:c, (:b, :a))}
 
 julia> pattern2 = :a --> (1, :a) # single-element autoconversion
 (:a,) --> (1, :a)
 
 julia> typeof(pattern2)
-ArrowPattern{(:a,), (1, :a)}
+Einops.ArrowPattern{(:a,), (1, :a)}
 
 julia> (:a, ..) --> :a # exported ellipsis notation
 (:a, EllipsisNotation.Ellipsis()) --> (:a,)

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+Einops = "e3ce28c8-8bfb-4704-8add-e3e7f14b55c9"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,0 +1,43 @@
+using Einops
+using Einops: @rearrange, @reshape, @reduce, @repeat, @einsum
+using Test
+
+@testset "Shorthand macros" begin
+    @testset "@rearrange" begin
+        x = rand(2, 3, 5)
+        @test @rearrange(x, "a b c -> c b a") == rearrange(x, einops"a b c -> c b a")
+        @test @rearrange(x, "a b c -> a (c b)") == rearrange(x, einops"a b c -> a (c b)")
+    end
+
+    @testset "@reshape" begin
+        x = rand(2, 3, 5)
+        @test @reshape(x, "a b c -> (a b) c") == reshape(x, einops"a b c -> (a b) c")
+    end
+
+    @testset "@reduce" begin
+        x = rand(2, 3)
+        @test @reduce(sum, x, "a b -> a") == reduce(sum, x, einops"a b -> a")
+    end
+
+    @testset "@repeat" begin
+        x = rand(2, 3)
+        @test @repeat(x, "a b -> a b c", c=4) == repeat(x, einops"a b -> a b c", c=4)
+        @test @repeat(x, "a b -> a b c"; c=4) == repeat(x, einops"a b -> a b c"; c=4)
+    end
+
+    @testset "@einsum" begin
+        x, y = rand(2, 3), rand(3, 4)
+        @test @einsum(x, y, "i j, j k -> i k") == einsum(x, y, einops"i j, j k -> i k")
+    end
+
+    @testset "context keyword" begin
+        x = rand(6, 5)
+        @test @rearrange(x, "(a b) c -> a b c", a=2) == rearrange(x, einops"(a b) c -> a b c", a=2)
+        @test @rearrange(x, "(a b) c -> a b c"; a=2) == rearrange(x, einops"(a b) c -> a b c"; a=2)
+    end
+
+    @testset "error handling" begin
+        @test_throws ArgumentError @macroexpand @rearrange(x, y)
+        @test_throws ArgumentError @macroexpand @rearrange(x, "a -> a", "b -> b")
+    end
+end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -32,8 +32,17 @@ using Test
 
     @testset "context keyword" begin
         x = rand(6, 5)
-        @test @rearrange(x, "(a b) c -> a b c", a=2) == rearrange(x, einops"(a b) c -> a b c", a=2)
-        @test @rearrange(x, "(a b) c -> a b c"; a=2) == rearrange(x, einops"(a b) c -> a b c"; a=2)
+        ref = rearrange(x, einops"(a b) c -> a b c"; a=2)
+        # comma form `, a=2`
+        @test @rearrange(x, "(a b) c -> a b c", a=2) == ref
+        # explicit `; a=2`
+        @test @rearrange(x, "(a b) c -> a b c"; a=2) == ref
+        # bare-symbol shorthand `; a`
+        a = 2
+        @test @rearrange(x, "(a b) c -> a b c"; a) == ref
+        # splat `; context...`
+        context = (; a=2)
+        @test @rearrange(x, "(a b) c -> a b c"; context...) == ref
     end
 
     @testset "error handling" begin

--- a/test/patterns.jl
+++ b/test/patterns.jl
@@ -4,11 +4,11 @@ using Test
 @testset "Pattern System" begin
     @testset "Core Types" begin
         @testset "ArrowPattern construction" begin
-            @test (() --> ()) isa ArrowPattern
-            @test (() --> :a) isa ArrowPattern
-            @test (:a --> ()) isa ArrowPattern
-            @test (:a --> :a) isa ArrowPattern
-            @test ((:a, ..) --> (:a,)) isa ArrowPattern
+            @test (() --> ()) isa Einops.ArrowPattern
+            @test (() --> :a) isa Einops.ArrowPattern
+            @test (:a --> ()) isa Einops.ArrowPattern
+            @test (:a --> :a) isa Einops.ArrowPattern
+            @test ((:a, ..) --> (:a,)) isa Einops.ArrowPattern
         end
 
         @testset "ArrowPattern interface" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ EINOPS_TEST_ZYGOTE && Pkg.add("Zygote")
     include("repeat.jl")
     include("einsum.jl")
     include("pack_unpack.jl")
+    include("macros.jl")
     include("robustness.jl")
 
     EINOPS_TEST_ZYGOTE && include("ext_zygote/runtests.jl")


### PR DESCRIPTION
Adds public `@rearrange`, `@reshape`, `@reduce`, `@repeat`, and `@einsum`.

Makes `ArrowPattern` public instead of exported.

Closes #2
Closes #29

Also uses `Rewrap.reshape` instead of `Base.reshape`, which might be relevant to #51