### PR TITLE
Directly expand to the generated expression in macros

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,58 +1,104 @@
-# Shorthand macros that let a pattern be written as a plain string literal
-# instead of `einops"..."`. Each `@f(args...)` expands to `f(args...)` with the
-# single string-literal argument replaced by its parsed pattern, so e.g.
+# Shorthand macros: write a pattern as a plain string instead of `einops"..."`. When
+# the pattern can be sized at expansion time the macro inlines the whole plan at the
+# call site (a `let`, no `@generated` call and no `Base.Pairs` — both fragile for
+# consumers like cuTile); otherwise it falls back to the function call. The pattern may
+# sit anywhere among the positional args, so the same helper serves every op.
 #
-#     @rearrange(x, "a b -> b a", k=1)   ==>   rearrange(x, (:a, :b) --> (:b, :a); k=1)
-#
-# The string can sit anywhere among the positional arguments, which is why the
-# same helper works for `einsum` (pattern last) as for `rearrange` (pattern
-# second) or `reduce` (pattern third).
+#     @rearrange(x, "a b -> b a")   ==>   let x = x; x = Permute((2, 1))(x); x end
+
+# Inlineable ops → (local var names for `*_body`, static builder, ellipsis builder).
+# `einsum` is absent: it routes through OMEinsum, not a reshape/permute plan.
+const INLINEABLE = Dict{Symbol,Tuple{Vector{Symbol},Function,Function}}(
+    :rearrange => ([:x],     rearrange_body, rearrange_body_ellipsis),
+    :reshape   => ([:x],     reshape_body,   reshape_body_ellipsis),
+    :reduce    => ([:f, :x], reduce_body,    reduce_body_ellipsis),
+    :repeat    => ([:x],     repeat_body,    repeat_body_ellipsis),
+)
 
 function einops_macro_call(f::Symbol, args)
-    positional = Any[]
-    kwargs = Any[]
-    found = false
+    positional = Any[]        # raw (unescaped) positional args, excluding the pattern
+    pattern = nothing         # parsed value of the string-literal pattern
+    pattern_index = 0         # its slot among the positional args (source order)
+    names = Symbol[]          # statically known keyword names
+    kwentries = Any[]         # `:kw`/`:...` entries for building the context NamedTuple
+    has_splat = false
     for a in args
         if Meta.isexpr(a, :parameters)
-            # keyword arguments passed after `;`
             for kw in a.args
-                push!(kwargs, _to_kw(kw))
+                _collect_kw!(kw, names, kwentries) && (has_splat = true)
             end
         elseif Meta.isexpr(a, :(=))
-            push!(kwargs, _to_kw(a))
+            _collect_kw!(a, names, kwentries)
         elseif a isa AbstractString
-            found && throw(ArgumentError("@$f expects a single string pattern argument"))
-            found = true
-            push!(positional, parse_pattern(a))
+            pattern_index == 0 || throw(ArgumentError("@$f expects a single string pattern argument"))
+            pattern = parse_pattern(a)
+            pattern_index = length(positional) + 1
         else
-            push!(positional, esc(a))
+            push!(positional, a)
         end
     end
-    found || throw(ArgumentError("@$f expects a string pattern argument"))
+    pattern_index == 0 && throw(ArgumentError("@$f expects a string pattern argument"))
+
+    inlined = try_inline(f, pattern, positional, names, kwentries, has_splat)
+    inlined === nothing || return inlined
+
+    # Fallback: reconstruct the original `f(positional...; kwargs...)` call, with the
+    # pattern restored to the slot it occupied in the source.
+    posargs = Any[esc(a) for a in positional]
+    insert!(posargs, pattern_index, pattern)
     call = Expr(:call, GlobalRef(@__MODULE__, f))
-    isempty(kwargs) || push!(call.args, Expr(:parameters, kwargs...))
-    append!(call.args, positional)
+    isempty(kwentries) || push!(call.args, Expr(:parameters, kwentries...))
+    append!(call.args, posargs)
     return call
 end
 
-# Normalize a single keyword entry for forwarding into the generated call's
-# `:parameters` block. The parser emits one of four forms here:
-#   the `; k` shorthand (a bare `Symbol`), a `; kws...` splat (`:...`), the
-#   `; obj.k` property shorthand (`:.`, naming the keyword after the field), or
-#   an explicit `k = v` (`:kw` from `; k=v`, or `:(=)` from a trailing `, k=v`).
-# Only values are escaped; key names are not.
-function _to_kw(kw)
-    kw isa Symbol && return Expr(:kw, kw, esc(kw))          # `; k`  ==>  `k = k`
-    Meta.isexpr(kw, :...) && return Expr(:..., esc(kw.args[1]))  # `; kws...`
-    Meta.isexpr(kw, :.) && return Expr(:kw, kw.args[2].value, esc(kw))  # `; obj.k`  ==>  `k = obj.k`
-    return Expr(:kw, kw.args[1], esc(kw.args[2]))           # `k = v`
+# Record a keyword entry: its statically-known name (if any) and the `:kw`/`:...` entry
+# for the context NamedTuple. Returns `true` for a `; kws...` splat (keys unknowable).
+function _collect_kw!(kw, names, kwentries)
+    if kw isa Symbol                                   # `; k`  ==>  `k = k`
+        push!(names, kw); push!(kwentries, Expr(:kw, kw, esc(kw))); return false
+    elseif Meta.isexpr(kw, :...)                       # `; kws...`
+        push!(kwentries, Expr(:..., esc(kw.args[1]))); return true
+    elseif Meta.isexpr(kw, :.)                         # `; obj.k`  ==>  `k = obj.k`
+        push!(names, kw.args[2].value); push!(kwentries, Expr(:kw, kw.args[2].value, esc(kw))); return false
+    else                                               # `k = v`
+        push!(names, kw.args[1]); push!(kwentries, Expr(:kw, kw.args[1], esc(kw.args[2]))); return false
+    end
 end
+
+# Returns an inlined expression, or `nothing` to signal "fall back to the call".
+function try_inline(f, pattern, positional, names, kwentries, has_splat)
+    haskey(INLINEABLE, f) || return nothing
+    pattern isa ArrowPattern || return nothing
+    vars, static_body, ellipsis_body = INLINEABLE[f]
+    length(positional) == length(vars) || return nothing
+
+    L, R = arrow_sides(pattern)
+    has_ellipsis = (..) in flatten(L) || (..) in flatten(R)
+    # A `; kws...` splat hides keys we'd need to resolve a multi-symbol left group's
+    # inferred axis; without such a group the splat only supplies values, which stay
+    # available through the runtime NamedTuple.
+    has_splat && has_multisymbol_group(L) && return nothing
+
+    plan = has_ellipsis ? ellipsis_body(L, R, Tuple(names)) :
+                          static_body(length(L), L, R, Tuple(names))
+    context = Expr(:tuple, Expr(:parameters, kwentries...))
+    bindings = Any[Expr(:(=), v, esc(p)) for (v, p) in zip(vars, positional)]
+    push!(bindings, Expr(:(=), :context, context))
+    return Expr(:let, Expr(:block, bindings...), plan)
+end
+
+arrow_sides(::ArrowPattern{L,R}) where {L,R} = (L, R)
+
+has_multisymbol_group(side) = any(el -> el isa Tuple && length(el) >= 2, side)
 
 """
     @rearrange(x, "pattern", context...)
 
 Shorthand for [`rearrange`](@ref) that takes the pattern as a string literal
-instead of `einops"..."`.
+instead of `einops"..."`. The reshape/permute plan is inlined at the call site
+(no `@generated` function, no `Base.Pairs` keyword object) whenever the pattern
+can be sized at macro-expansion time, otherwise it falls back to a `rearrange` call.
 
 # Examples
 
@@ -73,7 +119,7 @@ end
     @reshape(x, "pattern", context...)
 
 Shorthand for [`reshape`](@ref) that takes the pattern as a string literal
-instead of `einops"..."`.
+instead of `einops"..."`. See [`@rearrange`](@ref) for inlining behaviour.
 
 # Examples
 
@@ -94,7 +140,7 @@ end
     @reduce(f, x, "pattern", context...)
 
 Shorthand for [`reduce`](@ref) that takes the pattern as a string literal
-instead of `einops"..."`.
+instead of `einops"..."`. See [`@rearrange`](@ref) for inlining behaviour.
 
 # Examples
 
@@ -115,7 +161,7 @@ end
     @repeat(x, "pattern", context...)
 
 Shorthand for [`repeat`](@ref) that takes the pattern as a string literal
-instead of `einops"..."`.
+instead of `einops"..."`. See [`@rearrange`](@ref) for inlining behaviour.
 
 # Examples
 
@@ -136,7 +182,8 @@ end
     @einsum(arrays..., "pattern", context...)
 
 Shorthand for [`einsum`](@ref) that takes the pattern as a string literal
-instead of `einops"..."`.
+instead of `einops"..."`. Always expands to an `einsum` call (it is not type
+stable and routes through OMEinsum rather than a reshape/permute plan).
 
 # Examples
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -85,10 +85,22 @@ function try_inline(f, pattern, positional, names, kwentries, has_splat)
     context = Expr(:tuple, Expr(:parameters, kwentries...))
     bindings = Any[Expr(:(=), v, esc(p)) for (v, p) in zip(vars, positional)]
     push!(bindings, Expr(:(=), :context, context))
-    return Expr(:let, Expr(:block, bindings...), plan)
+    body = Expr(:block, rank_check(L, has_ellipsis), plan)
+    return Expr(:let, Expr(:block, bindings...), body)
 end
 
 arrow_sides(::ArrowPattern{L,R}) where {L,R} = (L, R)
+
+# Inlining builds the plan with `length(L)`, so `get_shape_in`'s `ndims(x)` rank check
+# collapses to a tautology and is lost. Re-emit it: an exact rank without an ellipsis,
+# a lower bound (the ellipsis must span ≥ 0 dims) with one. The non-ellipsis message
+# matches `get_shape_in`'s.
+function rank_check(L, has_ellipsis)
+    n = length(L) - has_ellipsis
+    has_ellipsis ?
+        :(ndims(x) >= $n || throw(ArgumentError(string("Input rank ", ndims(x), " is too small for pattern requiring at least ", $n, " dimensions")))) :
+        :(ndims(x) == $n || throw(ArgumentError(string("Input length ", $n, " does not match array dimensionality ", ndims(x)))))
+end
 
 has_multisymbol_group(side) = any(el -> el isa Tuple && length(el) >= 2, side)
 

--- a/src/rearrange.jl
+++ b/src/rearrange.jl
@@ -30,15 +30,45 @@ true
 @generated function rearrange(x, ::ArrowPattern{L,R}; context...) where {L,R}
     N = ndims(x)
     left, right = replace_ellipses(L, R, N)
-    shape_in = get_shape_in(N, left, pairs_type_to_names(context))
+    quote
+        context = NamedTuple(context)
+        $(rearrange_body(N, left, right, pairs_type_to_names(context)))
+    end
+end
+
+# `rearrange`'s plan, factored out so `@rearrange` can splice it inline. `left`/`right`
+# are ellipsis-resolved for `N`; the block operates on `x`/`context` and returns `x`.
+function rearrange_body(N, left, right, context_names)
+    shape_in = get_shape_in(N, left, context_names)
     permutation = get_permutation(extract(Symbol, left), extract(Symbol, right))
     shape_out = get_shape_out(right)
     quote
-        context = NamedTuple(context)
         $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
         $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
         $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        return x
+        x
+    end
+end
+
+# Ellipsis variant: rank is unknown at expansion, so the ellipsis run folds to `Keep(m)`
+# and the permutation expands via `Val(ndims(x))` (staging helpers in `utils.jl`).
+function rearrange_body_ellipsis(L, R, context_names)
+    left = replace_ellipsis_placeholder(L)
+    right = replace_ellipsis_placeholder(R)
+    m = ELLIPSIS_M
+    shape_in = get_shape_in(length(left), left, context_names)
+    permutation = get_permutation(extract(Symbol, left), extract(Symbol, right))
+    shape_out = get_shape_out(right)
+    pli = findfirst(==(ELLIPSIS_PLACEHOLDER), extract(Symbol, left))
+    isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
+    perm = permutation === ntuple(identity, length(permutation)) ? nothing : permute_run_expr(permutation, pli, m)
+    isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
+    quote
+        $(ellipsis_m_binding(L))
+        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
+        $(isnothing(perm) || :(x = $perm(x)))
+        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
+        x
     end
 end
 

--- a/src/rearrange.jl
+++ b/src/rearrange.jl
@@ -42,12 +42,12 @@ function rearrange_body(N, left, right, context_names)
     shape_in = get_shape_in(N, left, context_names)
     permutation = get_permutation(extract(Symbol, left), extract(Symbol, right))
     shape_out = get_shape_out(right)
-    quote
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block)
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    permutation === ntuple(identity, length(permutation)) || push!(body.args, :(x = $(Rewrap.Permute(permutation))(x)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end
 
 # Ellipsis variant: rank is unknown at expansion, so the ellipsis run folds to `Keep(m)`
@@ -63,33 +63,30 @@ function rearrange_body_ellipsis(L, R, context_names)
     isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
     perm = permutation === ntuple(identity, length(permutation)) ? nothing : permute_run_expr(permutation, pli, m)
     isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
-    quote
-        $(ellipsis_m_binding(L))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isnothing(perm) || :(x = $perm(x)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block, ellipsis_m_binding(L))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isnothing(perm) || push!(body.args, :(x = $perm(x)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end
 
 @generated function expand(x, ::Val{L}; context...) where {L}
     N = ndims(x)
     left = replace_ellipses_left(L, N)
     shape_in = get_shape_in(N, left, pairs_type_to_names(context); allow_repeats=true)
-    quote
-        context = NamedTuple(context)
-        $(isnothing(shape_in) || :(x = reshape(x, $shape_in)))
-        return x
-    end
+    body = Expr(:block, :(context = NamedTuple(context)))
+    isnothing(shape_in) || push!(body.args, :(x = reshape(x, $shape_in)))
+    push!(body.args, :(return x))
+    return body
 end
 
 @generated function collapse(x, ::Val{R}; context...) where {R}
     N = ndims(x)
     right = replace_ellipses_collapse(R, N)
     shape_out = get_shape_out(right)
-    quote
-        context = NamedTuple(context)
-        $(isnothing(shape_out) || :(x = reshape(x, $shape_out)))
-        return x
-    end
+    body = Expr(:block, :(context = NamedTuple(context)))
+    isnothing(shape_out) || push!(body.args, :(x = reshape(x, $shape_out)))
+    push!(body.args, :(return x))
+    return body
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -40,21 +40,60 @@ true
 @generated function reduce(f::Function, x, ::ArrowPattern{L,R}; context...) where {L,R}
     N = ndims(x)
     left, right = replace_ellipses(L, R, N)
+    quote
+        context = NamedTuple(context)
+        $(reduce_body(N, left, right, pairs_type_to_names(context)))
+    end
+end
+
+# See `rearrange_body` for the shared conventions; also operates on `f`.
+function reduce_body(N, left, right, context_names)
     left, extra_context = remove_anonymous_dims(left)
     left_names, right_names = extract(Symbol, left), extract(Symbol, right)
     isempty(setdiff(right_names, left_names)) || throw(ArgumentError("All dimension names on right side of pattern must be present on left side: $(setdiff(right_names, left_names))"))
     dims = get_mapping(left_names, setdiff(left_names, right_names))
-    shape_in = get_shape_in(N, left, (pairs_type_to_names(context)..., keys(extra_context)...))
+    shape_in = get_shape_in(N, left, (context_names..., keys(extra_context)...))
     permutation = get_permutation(intersect(left_names, right_names), right_names)
     drop_shape = get_dropdims_shape(length(left_names), dims)
     shape_out = get_shape_out(right)
     quote
-        context = NamedTuple(context)
         $(isempty(extra_context) || :(context = merge(context, $extra_context)))
         $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
         $(isempty(dims) || :(x = Rewrap.reshape(f(x; dims=$dims), $drop_shape)))
         $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
         $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        return x
+        x
+    end
+end
+
+# Ellipsis variant; see `rearrange_body_ellipsis`. Ellipsis dims are kept, never reduced.
+function reduce_body_ellipsis(L, R, context_names)
+    left = replace_ellipsis_placeholder(L)
+    right = replace_ellipsis_placeholder(R)
+    m = ELLIPSIS_M
+    left, extra_context = remove_anonymous_dims(left)
+    left_names, right_names = extract(Symbol, left), extract(Symbol, right)
+    isempty(setdiff(right_names, left_names)) || throw(ArgumentError("All dimension names on right side of pattern must be present on left side: $(setdiff(right_names, left_names))"))
+    dims = get_mapping(left_names, setdiff(left_names, right_names))
+    shape_in = get_shape_in(length(left), left, (context_names..., keys(extra_context)...))
+    kept = intersect(left_names, right_names)
+    permutation = get_permutation(kept, right_names)
+    drop_shape = get_dropdims_shape(length(left_names), dims)
+    shape_out = get_shape_out(right)
+    pli_left = findfirst(==(ELLIPSIS_PLACEHOLDER), left_names)
+    pli_kept = findfirst(==(ELLIPSIS_PLACEHOLDER), kept)
+    isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
+    dims_x = isempty(dims) ? dims : Expr(:tuple, (d < pli_left ? d : :($(d - 1) + $m) for d in dims)...)
+    expand_keep!(drop_shape, pli_left, m)
+    perm = permutation === ntuple(identity, length(permutation)) ? nothing : permute_run_expr(permutation, pli_kept, m)
+    isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
+    quote
+        $(ellipsis_m_binding(L))
+        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
+        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
+        $(isempty(dims) || :(x = Rewrap.reshape(f(x; dims=$dims_x), $drop_shape)))
+        $(isnothing(perm) || :(x = $perm(x)))
+        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
+        x
     end
 end

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -56,14 +56,14 @@ function reduce_body(N, left, right, context_names)
     permutation = get_permutation(intersect(left_names, right_names), right_names)
     drop_shape = get_dropdims_shape(length(left_names), dims)
     shape_out = get_shape_out(right)
-    quote
-        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isempty(dims) || :(x = Rewrap.reshape(f(x; dims=$dims), $drop_shape)))
-        $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block)
+    isempty(extra_context) || push!(body.args, :(context = merge(context, $extra_context)))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isempty(dims) || push!(body.args, :(x = Rewrap.reshape(f(x; dims=$dims), $drop_shape)))
+    permutation === ntuple(identity, length(permutation)) || push!(body.args, :(x = $(Rewrap.Permute(permutation))(x)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end
 
 # Ellipsis variant; see `rearrange_body_ellipsis`. Ellipsis dims are kept, never reduced.
@@ -87,13 +87,12 @@ function reduce_body_ellipsis(L, R, context_names)
     expand_keep!(drop_shape, pli_left, m)
     perm = permutation === ntuple(identity, length(permutation)) ? nothing : permute_run_expr(permutation, pli_kept, m)
     isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
-    quote
-        $(ellipsis_m_binding(L))
-        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isempty(dims) || :(x = Rewrap.reshape(f(x; dims=$dims_x), $drop_shape)))
-        $(isnothing(perm) || :(x = $perm(x)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block, ellipsis_m_binding(L))
+    isempty(extra_context) || push!(body.args, :(context = merge(context, $extra_context)))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isempty(dims) || push!(body.args, :(x = Rewrap.reshape(f(x; dims=$dims_x), $drop_shape)))
+    isnothing(perm) || push!(body.args, :(x = $perm(x)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end

--- a/src/repeat.jl
+++ b/src/repeat.jl
@@ -69,17 +69,17 @@ function repeat_body(N, left, right, context_names)
     repeats = [:(getfield(context, $(QuoteNode(name)))) for name in repeat_names]
     repeat_dims = [i in positions ? repeats[findfirst(==(i), positions)] : 1 for i in 1:maximum(positions; init=0)]
     shape_out = get_shape_out(right)
-    quote
-        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
-        $(all(==(1), repeat_dims) || :(
-            x = Rewrap.reshape(x, $(reshape_pre_repeat(length(left_names), positions)));
-            x = Repeat(($(repeat_dims...),))(x)
-        ))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
+    body = Expr(:block)
+    isempty(extra_context) || push!(body.args, :(context = merge(context, $extra_context)))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    permutation === ntuple(identity, length(permutation)) || push!(body.args, :(x = $(Rewrap.Permute(permutation))(x)))
+    if !all(==(1), repeat_dims)
+        push!(body.args, :(x = Rewrap.reshape(x, $(reshape_pre_repeat(length(left_names), positions)))))
+        push!(body.args, :(x = Repeat(($(repeat_dims...),))(x)))
     end
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end
 
 # Ellipsis variant; see `rearrange_body_ellipsis`. Ellipsis dims are kept (never
@@ -115,16 +115,15 @@ function repeat_body_ellipsis(L, R, context_names)
     end
     isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
 
-    quote
-        $(ellipsis_m_binding(L))
-        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isnothing(perm) || :(x = $perm(x)))
-        $(!do_repeat || :(
-            x = Rewrap.reshape(x, $pre_repeat);
-            x = Repeat($repeat_tuple)(x)
-        ))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
+    body = Expr(:block, ellipsis_m_binding(L))
+    isempty(extra_context) || push!(body.args, :(context = merge(context, $extra_context)))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isnothing(perm) || push!(body.args, :(x = $perm(x)))
+    if do_repeat
+        push!(body.args, :(x = Rewrap.reshape(x, $pre_repeat)))
+        push!(body.args, :(x = Repeat($repeat_tuple)(x)))
     end
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end

--- a/src/repeat.jl
+++ b/src/repeat.jl
@@ -46,18 +46,30 @@ true
 @generated function repeat(x, ::ArrowPattern{L,R}; context...) where {L,R}
     N = ndims(x)
     left, right = replace_ellipses(L, R, N)
+    quote
+        context = NamedTuple(context)
+        $(repeat_body(N, left, right, pairs_type_to_names(context)))
+    end
+end
+
+# Resolve ambiguity with `Base.repeat(::AbstractArray, counts...)`: the untyped method is
+# more specific in the pattern, Base's in the array, so `AbstractArray` needs its own.
+repeat(x::AbstractArray, pattern::ArrowPattern; context...) =
+    invoke(repeat, Tuple{Any,ArrowPattern}, x, pattern; context...)
+
+# See `rearrange_body` for the shared conventions.
+function repeat_body(N, left, right, context_names)
     right, extra_context = remove_anonymous_dims(right)
     left_names, right_names = extract(Symbol, left), extract(Symbol, right)
     repeat_names = setdiff(right_names, left_names)
     right_names_no_repeat = setdiff(right_names, repeat_names)
-    shape_in = get_shape_in(N, left, pairs_type_to_names(context))
+    shape_in = get_shape_in(N, left, context_names)
     permutation = get_permutation(left_names, right_names_no_repeat)
     positions = get_mapping(right_names, repeat_names)
     repeats = [:(getfield(context, $(QuoteNode(name)))) for name in repeat_names]
     repeat_dims = [i in positions ? repeats[findfirst(==(i), positions)] : 1 for i in 1:maximum(positions; init=0)]
     shape_out = get_shape_out(right)
     quote
-        context = NamedTuple(context)
         $(isempty(extra_context) || :(context = merge(context, $extra_context)))
         $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
         $(permutation === ntuple(identity, length(permutation)) || :(x = $(Rewrap.Permute(permutation))(x)))
@@ -66,12 +78,53 @@ true
             x = Repeat(($(repeat_dims...),))(x)
         ))
         $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        return x
+        x
     end
 end
 
-# Resolve ambiguity with `Base.repeat(::AbstractArray, counts...)`: the untyped
-# method above is more specific in the pattern argument, Base's is more specific
-# in the array argument, so an explicit method is needed for `AbstractArray`s.
-repeat(x::AbstractArray, pattern::ArrowPattern; context...) =
-    invoke(repeat, Tuple{Any,ArrowPattern}, x, pattern; context...)
+# Ellipsis variant; see `rearrange_body_ellipsis`. Ellipsis dims are kept (never
+# repeated), so their `Repeat` factor slot expands to a run of 1's.
+function repeat_body_ellipsis(L, R, context_names)
+    left = replace_ellipsis_placeholder(L)
+    right = replace_ellipsis_placeholder(R)
+    m = ELLIPSIS_M
+    right, extra_context = remove_anonymous_dims(right)
+    left_names, right_names = extract(Symbol, left), extract(Symbol, right)
+    repeat_names = setdiff(right_names, left_names)
+    right_names_no_repeat = setdiff(right_names, repeat_names)
+    shape_in = get_shape_in(length(left), left, context_names)
+    permutation = get_permutation(left_names, right_names_no_repeat)
+    positions = get_mapping(right_names, repeat_names)
+    repeats = [:(getfield(context, $(QuoteNode(name)))) for name in repeat_names]
+    repeat_dims = Any[i in positions ? repeats[findfirst(==(i), positions)] : 1 for i in 1:maximum(positions; init=0)]
+    shape_out = get_shape_out(right)
+
+    pli_left = findfirst(==(ELLIPSIS_PLACEHOLDER), left_names)
+    pli_norepeat = findfirst(==(ELLIPSIS_PLACEHOLDER), right_names_no_repeat)
+    pli_right = findfirst(==(ELLIPSIS_PLACEHOLDER), right_names)
+
+    isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
+    perm = permutation === ntuple(identity, length(permutation)) ? nothing : permute_run_expr(permutation, pli_left, m)
+    do_repeat = !all(==(1), repeat_dims)
+    pre_repeat = repeat_tuple = nothing
+    if do_repeat
+        pre_repeat = reshape_pre_repeat(length(left_names), positions)
+        expand_keep!(pre_repeat, nth_keep_index(pre_repeat, pli_norepeat), m)
+        pli_right <= length(repeat_dims) && (repeat_dims[pli_right] = Expr(:..., :(ntuple(Returns(1), Val($m)))))
+        repeat_tuple = Expr(:tuple, repeat_dims...)
+    end
+    isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
+
+    quote
+        $(ellipsis_m_binding(L))
+        $(isempty(extra_context) || :(context = merge(context, $extra_context)))
+        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
+        $(isnothing(perm) || :(x = $perm(x)))
+        $(!do_repeat || :(
+            x = Rewrap.reshape(x, $pre_repeat);
+            x = Repeat($repeat_tuple)(x)
+        ))
+        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
+        x
+    end
+end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -23,15 +23,42 @@ julia> reshape(x, (:a, :b, :c) --> ((:a, :b), :c)) |> size
 @generated function Base.reshape(x, ::ArrowPattern{L,R}; context...) where {L,R}
     N = ndims(x)
     left, right = replace_ellipses(L, R, N)
+    quote
+        context = NamedTuple(context)
+        $(reshape_body(N, left, right, pairs_type_to_names(context)))
+    end
+end
+
+# See `rearrange_body` for the shared conventions.
+function reshape_body(N, left, right, context_names)
     left_symbols = extract(Symbol, left)
     right_symbols = extract(Symbol, right)
     left_symbols == right_symbols || throw(ArgumentError("reshape requires symbols in same order on both sides. Got $left_symbols vs $right_symbols. Use rearrange for permutations."))
-    shape_in = get_shape_in(N, left, pairs_type_to_names(context))
+    shape_in = get_shape_in(N, left, context_names)
     shape_out = get_shape_out(right)
     quote
-        context = NamedTuple(context)
         $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
         $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        return x
+        x
+    end
+end
+
+# Ellipsis variant; see `rearrange_body_ellipsis`.
+function reshape_body_ellipsis(L, R, context_names)
+    left = replace_ellipsis_placeholder(L)
+    right = replace_ellipsis_placeholder(R)
+    m = ELLIPSIS_M
+    left_symbols = extract(Symbol, left)
+    right_symbols = extract(Symbol, right)
+    left_symbols == right_symbols || throw(ArgumentError("reshape requires symbols in same order on both sides. Got $left_symbols vs $right_symbols. Use rearrange for permutations."))
+    shape_in = get_shape_in(length(left), left, context_names)
+    shape_out = get_shape_out(right)
+    isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
+    isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
+    quote
+        $(ellipsis_m_binding(L))
+        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
+        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
+        x
     end
 end

--- a/src/reshape.jl
+++ b/src/reshape.jl
@@ -36,11 +36,11 @@ function reshape_body(N, left, right, context_names)
     left_symbols == right_symbols || throw(ArgumentError("reshape requires symbols in same order on both sides. Got $left_symbols vs $right_symbols. Use rearrange for permutations."))
     shape_in = get_shape_in(N, left, context_names)
     shape_out = get_shape_out(right)
-    quote
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block)
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end
 
 # Ellipsis variant; see `rearrange_body_ellipsis`.
@@ -55,10 +55,9 @@ function reshape_body_ellipsis(L, R, context_names)
     shape_out = get_shape_out(right)
     isnothing(shape_in) || expand_keep!(shape_in, findfirst(==(ELLIPSIS_PLACEHOLDER), left), m)
     isnothing(shape_out) || expand_shape_out!(shape_out, right, m)
-    quote
-        $(ellipsis_m_binding(L))
-        $(isnothing(shape_in) || :(x = Rewrap.reshape(x, $shape_in)))
-        $(isnothing(shape_out) || :(x = Rewrap.reshape(x, $shape_out)))
-        x
-    end
+    body = Expr(:block, ellipsis_m_binding(L))
+    isnothing(shape_in) || push!(body.args, :(x = Rewrap.reshape(x, $shape_in)))
+    isnothing(shape_out) || push!(body.args, :(x = Rewrap.reshape(x, $shape_out)))
+    push!(body.args, :x)
+    return body
 end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -65,3 +65,70 @@ function get_dropdims_shape(N::Int, dims::Tuple{Vararg{Int}})
     end
     return new_shape
 end
+
+# === Ellipsis inlining for the shorthand macros ===
+#
+# With an ellipsis the rank N = ndims(x) is unknown at expansion, so the span it covers,
+# `m = N - C`, rides in as the folded constant `ndims(x) - C`. The structure is still
+# built at expansion: the ellipsis becomes one placeholder symbol, the ordinary builders
+# run, then each N-dependent piece is rewritten in terms of `m` — a kept run folds to a
+# single `Keep(m)`, a fixed+ellipsis merge to `Merge((k-1)+m)`, reduced indices past it
+# shift by `m-1`, and the permutation expands its slot via `ntuple(_, Val(m))`.
+
+const ELLIPSIS_PLACEHOLDER = Symbol("__ellipsis_placeholder__")
+
+# Replace the ellipsis (`..`, possibly nested on the right) with the placeholder.
+replace_ellipsis_placeholder(side) =
+    map(el -> el == (..) ? ELLIPSIS_PLACEHOLDER :
+              el isa Tuple ? replace_ellipsis_placeholder(el) : el, side)
+
+# `m` is captured once at the top of the body, since `x` is reassigned as the plan runs
+# and `ndims(x)` would otherwise drift. C = length(L) - 1 (every left entry but the slot).
+const ELLIPSIS_M = Symbol("__ellipsis_m__")
+ellipsis_m_binding(L) = :($ELLIPSIS_M = ndims(x) - $(length(L) - 1))
+
+keep_run(m) = Expr(:call, Keep, m)                        # Keep(m)
+merge_span(k, m) = Expr(:call, Merge, :($(k - 1) + $m))   # Merge((k-1) + m)
+
+# Expand the placeholder's permutation slot into the run `pli, …, pli+m-1`; shift later
+# indices by m-1.
+function permute_run_expr(permutation, pli, m)
+    entries = Any[]
+    for e in permutation
+        if e < pli
+            push!(entries, e)
+        elseif e == pli
+            push!(entries, Expr(:..., :(ntuple(i -> i + $(pli - 1), Val($m)))))
+        else
+            push!(entries, :($(e - 1) + $m))
+        end
+    end
+    return Expr(:call, Permute, Expr(:tuple, entries...))
+end
+
+# Swap the op at top-level entry `i` (the placeholder's `Keep()`) for `Keep(m)`.
+expand_keep!(ops::Expr, i, m) = (ops.args[i] = keep_run(m); ops)
+
+# Placeholder is either a top-level `Keep` (→ `Keep(m)`) or inside a merged group (→ bump).
+function expand_shape_out!(shape_out::Expr, right, m)
+    oidx = findfirst(==(ELLIPSIS_PLACEHOLDER), right)
+    if oidx !== nothing
+        shape_out.args[oidx] = keep_run(m)
+    else
+        gidx = findfirst(t -> t isa Tuple && ELLIPSIS_PLACEHOLDER in t, right)
+        shape_out.args[gidx] = merge_span(length(right[gidx]), m)
+    end
+    return shape_out
+end
+
+# Index of the `n`-th `Keep` op (locates the placeholder keep among interleaved `Unsqueeze`s).
+function nth_keep_index(ops::Expr, n)
+    count = 0
+    for (i, op) in enumerate(ops.args)
+        if Meta.isexpr(op, :call) && op.args[1] === Keep
+            count += 1
+            count == n && return i
+        end
+    end
+    error("placeholder keep not found")
+end

--- a/test/builders.jl
+++ b/test/builders.jl
@@ -1,0 +1,47 @@
+using Einops
+using Einops: rearrange_body, rearrange_body_ellipsis, reshape_body, reshape_body_ellipsis,
+              reduce_body, reduce_body_ellipsis, repeat_body, repeat_body_ellipsis, nth_keep_index
+using Test
+
+# The plan builders run only at compile time (inside the `@generated` ops) and at
+# macro-expansion time (inside the `@…` macros), so line-coverage never attributes them
+# even though every op test exercises them. Call them directly here: building a `quote`
+# evaluates its `$(...)` interpolations, so the lines register. Each result is also
+# `@eval`'d inside `Einops` (where `Rewrap` et al. resolve) and run, so these double as
+# isolated correctness checks against the public ops.
+
+@eval Einops begin
+    _cov_rearrange(x)     = (context = (; a=2); $(rearrange_body(2, ((:a,:b),:c), (:c,(:a,:b)), (:a,))))
+    _cov_rearrange_ell(x) =                     $(rearrange_body_ellipsis((:a, .., :b), (:a, (:b, ..)), ()))
+    _cov_reshape(x)       =                     $(reshape_body(3, (:a,:b,:c), ((:a,:b),:c), ()))
+    _cov_reshape_ell(x)   = (context = (; a=2); $(reshape_body_ellipsis((1, (:a,:b), ..), (:a, (:b, ..)), (:a,))))
+    _cov_reduce(f, x)     =                     $(reduce_body(3, (:a,:b,:c), (:a,:c), ()))
+    _cov_reduce_ell(f, x) =                     $(reduce_body_ellipsis((:c, .., :t), (:c, ..), ()))
+    _cov_repeat(x)        = (context = (; r=2); $(repeat_body(2, (:a,:b), (:a,:b,:r), (:r,))))
+    _cov_repeat_ell(x)    = (context = (; r=2); $(repeat_body_ellipsis((:a, ..), (:a, .., :r), (:r,))))
+end
+
+@testset "plan builders" begin
+    @testset "static builders match the ops" begin
+        x = rand(6, 5)
+        @test Einops._cov_rearrange(x) == rearrange(x, einops"(a b) c -> c (a b)"; a=2)
+        x3 = rand(2, 3, 5)
+        @test Einops._cov_reshape(x3) == reshape(x3, einops"a b c -> (a b) c")
+        @test Einops._cov_reduce(sum, x3) == reduce(sum, x3, einops"a b c -> a c")
+        @test Einops._cov_repeat(x) == repeat(x, einops"a b -> a b r"; r=2)
+    end
+
+    @testset "ellipsis builders match the ops" begin
+        x4 = rand(2, 3, 4, 5)
+        @test Einops._cov_rearrange_ell(x4) == rearrange(x4, einops"a ... b -> a (b ...)")
+        xr = rand(1, 6, 2, 3)
+        @test Einops._cov_reshape_ell(xr) == reshape(xr, einops"1 (a b) ... -> a (b ...)"; a=2)
+        @test Einops._cov_reduce_ell(sum, x4) == reduce(sum, x4, einops"c ... t -> c ...")
+        x2 = rand(2, 3)
+        @test Einops._cov_repeat_ell(x2) == repeat(x2, einops"a ... -> a ... r"; r=2)
+    end
+
+    @testset "nth_keep_index defensive branch" begin
+        @test_throws ErrorException nth_keep_index(Expr(:tuple), 1)
+    end
+end

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -121,6 +121,19 @@ using Test
         end
     end
 
+    @testset "inlining preserves rank validation" begin
+        # A rank-mismatched no-op pattern must still error, matching the function path,
+        # rather than silently returning the array (the inlined plan skips get_shape_in's
+        # rank check, so the macro re-emits it).
+        @test_throws ArgumentError @rearrange(rand(2, 3, 4), "a b -> a b")
+        @test_throws ArgumentError @reshape(rand(2, 3, 4), "a b -> a b")
+        @test_throws ArgumentError @reduce(sum, rand(5), "a b -> a")
+        @test_throws ArgumentError @repeat(rand(2, 3, 4), "a b -> a b r", r=2)
+        # ellipsis must span ≥ 0 dims
+        @test_throws ArgumentError @rearrange(rand(2), "a b ... -> ... b a")
+        @test (@rearrange(rand(2, 3), "a b ... -> ... b a"); true)  # 0-dim ellipsis is fine
+    end
+
     @testset "inlined plans are type stable" begin
         # Mirrors the constant-folding cuTile relies on: rank enters via the arg type.
         r1(x) = @rearrange(x, "a ... b -> b ... a")

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -51,4 +51,89 @@ using Test
         @test_throws ArgumentError @macroexpand @rearrange(x, y)
         @test_throws ArgumentError @macroexpand @rearrange(x, "a -> a", "b -> b")
     end
+
+    # The macros inline the plan at the call site. Every case below also asserts
+    # equality with the generated-function path, so the inlined plan and the
+    # generated plan are checked against each other.
+    is_inlined(ex) = Meta.isexpr(ex, :let)
+
+    @testset "inlining vs fallback" begin
+        x = rand(2, 3, 5)
+        # statically sizable -> inlined `let`, no `rearrange` call, no Base.Pairs
+        @test is_inlined(@macroexpand @rearrange(x, "a b c -> c b a"))
+        @test is_inlined(@macroexpand @reshape(x, "a b c -> (a b) c"))
+        @test is_inlined(@macroexpand @reduce(sum, x, "a b c -> a c"))
+        @test is_inlined(@macroexpand @repeat(x, "a b -> a b r", r=2))
+        # ellipsis -> still inlined (rank rides in via Val(ndims(x)))
+        @test is_inlined(@macroexpand @rearrange(x, "a ... -> ... a"))
+        # einsum -> always a call (not type stable / OMEinsum path)
+        @test !is_inlined(@macroexpand @einsum(x, x, "a b c, a b c -> a"))
+        # `; kws...` splat with a multi-symbol left group -> fall back to call
+        @test !is_inlined(@macroexpand @rearrange(x, "(a b) c -> a b c"; ctx...))
+        # `; kws...` splat without such a group -> still inlined (splat carries values)
+        @test is_inlined(@macroexpand @repeat(x, "a b c -> a b c r"; ctx...))
+    end
+
+    @testset "splat fallback correctness" begin
+        x = rand(6, 5)
+        ctx = (; a = 2)
+        @test @rearrange(x, "(a b) c -> a b c"; ctx...) == rearrange(x, einops"(a b) c -> a b c"; ctx...)
+        r = (; r = 3)
+        @test @repeat(x, "a c -> a c r"; r...) == repeat(x, einops"a c -> a c r"; r...)
+    end
+
+    @testset "ellipsis inlining vs generated" begin
+        @testset "rearrange" begin
+            for x in (rand(2, 3), rand(2, 3, 4), rand(2, 3, 4, 5))
+                @test @rearrange(x, "a ... b -> b ... a") == rearrange(x, einops"a ... b -> b ... a")
+                @test @rearrange(x, "a ... b -> a ... b") == rearrange(x, einops"a ... b -> a ... b")
+                @test @rearrange(x, "... a -> a ...") == rearrange(x, einops"... a -> a ...")
+            end
+            for x in (rand(2, 3, 4), rand(2, 3, 4, 5, 6))
+                @test @rearrange(x, "a ... b -> (a b) ...") == rearrange(x, einops"a ... b -> (a b) ...")
+                @test @rearrange(x, "a ... b -> a (b ...)") == rearrange(x, einops"a ... b -> a (b ...)")
+            end
+            for x in (rand(6, 3, 4), rand(6, 3, 4, 5))
+                @test @rearrange(x, "(a c) ... b -> b ... a c", a=2) == rearrange(x, einops"(a c) ... b -> b ... a c"; a=2)
+            end
+        end
+
+        @testset "reshape" begin
+            for x in (rand(1, 6, 2, 3), rand(1, 6, 2, 3, 4))
+                @test @reshape(x, "1 (a b) ... -> a (b ...)"; a=2) == reshape(x, einops"1 (a b) ... -> a (b ...)"; a=2)
+            end
+        end
+
+        @testset "reduce" begin
+            for x in (rand(4, 3, 5), rand(4, 3, 5, 6))
+                @test @reduce(sum, x, "c ... t -> c ...") == reduce(sum, x, einops"c ... t -> c ...")
+                @test @reduce(sum, x, "c ... t -> ... c") == reduce(sum, x, einops"c ... t -> ... c")
+                @test @reduce(maximum, x, "c d ... -> c ...") == reduce(maximum, x, einops"c d ... -> c ...")
+            end
+        end
+
+        @testset "repeat" begin
+            for x in (rand(2, 3), rand(2, 3, 4))
+                @test @repeat(x, "a ... -> a ... r", r=2) == repeat(x, einops"a ... -> a ... r"; r=2)
+                @test @repeat(x, "a ... -> r a ...", r=2) == repeat(x, einops"a ... -> r a ..."; r=2)
+                @test @repeat(x, "a ... -> a ...") == repeat(x, einops"a ... -> a ...")
+            end
+        end
+    end
+
+    @testset "inlined plans are type stable" begin
+        # Mirrors the constant-folding cuTile relies on: rank enters via the arg type.
+        r1(x) = @rearrange(x, "a ... b -> b ... a")
+        r2(x) = @rearrange(x, "(a c) ... b -> b ... a c", a=2)
+        r3(x) = @reshape(x, "1 (a b) ... -> a (b ...)"; a=2)
+        r4(x) = @reduce(sum, x, "c ... t -> ... c")
+        r5(x) = @repeat(x, "a ... -> a ... r", r=2)
+        s1(x) = @rearrange(x, "(k1 m2 m1) k0 m0 -> (k1 k0) (m1 m2 m0)"; k1=4, m2=4)
+        @test (@inferred r1(rand(2, 3, 4, 5)); true)
+        @test (@inferred r2(rand(6, 3, 4, 5)); true)
+        @test (@inferred r3(rand(1, 6, 2, 3, 4)); true)
+        @test (@inferred r4(rand(4, 3, 5, 6)); true)
+        @test (@inferred r5(rand(2, 3, 4)); true)
+        @test (@inferred s1(rand(512, 7, 8)); true)
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,6 +17,7 @@ EINOPS_TEST_ZYGOTE && Pkg.add("Zygote")
     include("einsum.jl")
     include("pack_unpack.jl")
     include("macros.jl")
+    include("builders.jl")
     include("robustness.jl")
 
     EINOPS_TEST_ZYGOTE && include("ext_zygote/runtests.jl")


### PR DESCRIPTION
This avoids some nasty downstream cuTile.jl bugs involving the interpreter not being able constprop through keyword arguments **if Einops is imported before cuTile** — it works if cuTile is imported first.

By changing the macros to directly expand to the code that the generated functions would generate, we avoid passing the context as keywords arguments and also helps reduce overspecialization (#13). It also makes the code that it expands to more transparent since users can now observe with `@macroexpand @rearrange(...)`.